### PR TITLE
RFC: Add initial CMake build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,111 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(llgen)
+
+option(BUILD_LLDUMP OFF "Build lldump")
+option(BUILD_DEXPR OFF "Build dexpr")
+option(BUILD_PARSER OFF "Build parsers using lex/flex and yacc/bison")
+option(BUILD_STRUCTGRAM OFF "Build structgram")
+
+find_library(MATH_LIBRARY m)
+
+# Platform-specific defines
+if(WIN32)
+    add_definitions(-DWINDOWS)
+    add_definitions(-DYY_NO_UNISTD_H)
+elseif(UNIX)
+    add_definitions(-DUNIX)
+endif()
+
+# Compiler-specific defines
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
+set(LLGEN_SOURCES
+    llgen.c
+    gram2.tab.c
+    scan2.yy.c
+    avl3.c
+    storage.c
+    regexp.c
+    lang.c)
+
+set(LLDUMP_SOURCES
+    lldump.c
+    gram2.tab.c
+    scan2.yy.c
+    avl3.c
+    storage.c
+    regexp.c
+    paramlist.c)
+
+set(STRUCTGRAM_SOURCES
+    structgram.c
+    storage.c
+    avl3.c)
+
+set(DEXPR_SOURCES
+    dexpr.main.c
+    dexpr.c
+    gregjul.c)
+
+add_executable(llgen ${LLGEN_SOURCES})
+
+if(BUILD_STRUCTGRAM)
+    add_executable(structgram ${STRUCTGRAM_SOURCES})
+
+    add_custom_command(
+    OUTPUT ${CMAKE_SOURCE_DIR}/structgram.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/structgram.ll
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    VERBATIM
+    COMMAND llgen ${CMAKE_SOURCE_DIR}/structgram.ll)
+endif()
+
+if(BUILD_DEXPR)
+    add_executable(dexpr ${DEXPR_SOURCES})
+
+    # Just unconditionally link against the m library if found
+    # Does nothing on Windows and works fine on Unix-like
+    if(MATH_LIBRARY)
+        target_link_libraries(dexpr ${MATH_LIBRARY})
+    endif()
+endif()
+
+if(BUILD_LLDUMP)
+    add_executable(lldump ${LLDUMP_SOURCES})
+endif()
+
+if(BUILD_PARSERS)
+    # Test for parser tools before trying to build wit them.
+    find_program(LEX_EXE flex lex)
+    find_program(YACC_EXE bison win-bison win_bison byacc yacc)
+
+    if(NOT LEX_EXE)
+        message(SEND_ERROR "Failed to find lex-like program.")
+    endif()
+
+    if(NOT YACC_EXE)
+        message(SEND_ERROR "Failed to find yacc-like program.")
+    endif()
+
+    if(NOT LEX_EXE OR NOT YACC_EXE)
+        message(FATAL_ERROR "Requested parser generation but can't find tools.")
+    endif()
+
+    # We explicitly use CMAKE_SOURCE_DIR for outputs and
+    # working directory. Those are otherwise user controlled
+    # and we expect them in a particular place.
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/gram2.tab.c ${CMAKE_SOURCE_DIR}/gram2.tab.h
+        DEPENDS ${CMAKE_SOURCE_DIR}/gram2.y
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        VERBATIM
+        COMMAND ${YACC_EXE} -d ${CMAKE_SOURCE_DIR}/gram2.y)
+
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/scan2.yy.c
+        DEPENDS ${CMAKE_SOURCE_DIR}/scan2.l
+        VERBATIM
+        COMMAND ${LEX_EXE} -t ${CMAKE_SOURCE_DIR}/scan2.l > ${CMAKE_SOURCE_DIR}/scan2.yy.c)
+endif()

--- a/llgen.c
+++ b/llgen.c
@@ -3,14 +3,11 @@
 #include <string.h>
 #include <stdarg.h>
 #include <ctype.h>
-#ifdef unix
+#ifdef UNIX
 #define DIR_SEP_CHAR '/'
 #endif
-#ifdef windows
+#ifdef WINDOWS
 #define DIR_SEP_CHAR '\\'
-#endif
-#ifdef __MACH__
-#define DIR_SEP_CHAR '/'
 #endif
 #ifndef DIR_SEP_CHAR
 #error "unknown platform"


### PR DESCRIPTION
I couldn't build the binaries with MSVC or MinGW with the Makefile (as in, it wouldn't compile). I ended up modifying it a fair bit and figured I might as well try out a CMake script. So here we are. 

There are differences:

* When compiling with MSVC, we define `_CRT_SECURE_NO_WARNINGS` for all targets.
* I changed the platform defines from unix/windows to UNIX/WINDOWS to fit other defines. The build system defines those based on target platform.
* When building for Windows, `unistd.h` is explicitly ignored in Flex output by defining `YY_NO_UNISTD_H`. There might be more portable ways of accomplishing that, I only know it works with Flex.
* It doesn't try to build parser files using lex and yacc by default, it's hidden behind a conditional.

However, there are various problems:

* There are various source files missing, namely `lldump.c`, `dexpr.main.c`, and `structgram.ll` (which makes `structgram.c`). Because lldump, dexpr, and strugram are missing files, I have no way to know if those compile like they're supposed to. They are disabled by default. By default, only llgen is built.
* I don't have a Linux machine. I've only tested with:
  - Cygwin with Makefiles and Ninja, all with and without Bison/Flex
  - MinGW with Makefiles and Ninja, all with and without Bison/Flex
  - MSVC with Ninja and MSBuild
* There are more warnings than I'm comfortable with. I'm not sure what's normal here.

*Anyways*, this merge request isn't meant to be merged as is, more to test waters and see if there's interest.